### PR TITLE
Added more protocol and some other changes

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -53,7 +53,8 @@
 #endif
 
 /* Format for protocol definitions:
- * { 
+ * {
+ *  protocol ID,
  *  pulselength, 
  *  sync bit before the data bits. Normally zero, i.e. {0, 0},
  *  "0" bit, 
@@ -93,7 +94,7 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
     {8, 250, {1, 10}, {1, 5}, {1, 1}, {1, 40}, false},  // protocol 8 (Nexa)
     {9, 100, {0, 0}, {6, 6}, {6, 12}, {6, 169}, false}, // protocol 9 (Everflourish Single Button)
     {10, 100, {0, 0}, {6, 6}, {6, 12}, {6, 120}, false}, // protocol 10 (Everflourish All Buttons)
-    {11, 500, {7, 7}, {1, 1}, {1, 2}, {1, 40}, false},   // protocol 11 (Cixi Yidong Electronics , sold as AXXEL, Telco, EVOLOGY, CONECTO, mumbi, Manax etc.)
+    {11, 250, {14, 14}, {2, 2}, {2, 5}, {2, 80}, false}, // protocol 11 (Cixi Yidong Electronics , sold as AXXEL, Telco, EVOLOGY, CONECTO, mumbi, Manax etc.)
 };
 
 enum
@@ -1001,7 +1002,7 @@ bool RECEIVE_ATTR RCSwitch::receiveProtocol(const int p, unsigned int changeCoun
   // For protocol 11 (Cixi Yidong), the first 16 bits of the 40 bits stores the remote control ID,
   // the second 16 bit is the ones' complement of the fir two bytes.
   // The last byte is the button code and command odd numbers are ON, even number are OFF commands.
-  // Number 0b10100101/0xA5/165 measn all ON, 
+  // Number 0b10100101/0xA5/165 means all ON, 
   // number 0b01011010/0X5A/90 means all OFF assigned to the same remote ID.
   // As one integer number, it is enough to store the first 16 and the last 8 bits to rebuild the whole 40 bits bitsream.
   {

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -81,7 +81,7 @@ class RCSwitch
     void send(unsigned long code, unsigned int length);
     void send(const char *sBitString);
 
-#if not defined(RCSwitchDisableReceiving)
+#ifndef RCSwitchDisableReceiving
     void enableReceive(int interrupt);
     void enableReceive();
     void disableReceive();
@@ -100,7 +100,7 @@ class RCSwitch
     void disableTransmit();
     void setPulseLength(int nPulseLength);
     void setRepeatTransmit(int nRepeatTransmit);
-#if not defined(RCSwitchDisableReceiving)
+#ifndef RCSwitchDisableReceiving
     void setReceiveTolerance(int nPercent);
 #endif
 
@@ -122,6 +122,7 @@ class RCSwitch
      */
     struct Protocol
     {
+        uint8_t protocolId;
         /** base pulse length in microseconds, e.g. 350 */
         uint16_t pulseLength;
 
@@ -167,7 +168,7 @@ class RCSwitch
     char *getCodeWordC(char sFamily, int nGroup, int nDevice, bool bStatus);
     char *getCodeWordD(char group, int nDevice, bool bStatus);
 
-#if not defined(RCSwitchDisableReceiving)
+#ifndef RCSwitchDisableReceiving
     static void handleInterrupt();
     static bool receiveProtocol(const int p, unsigned int changeCount);
     int nReceiverInterrupt;
@@ -177,7 +178,7 @@ class RCSwitch
 
     Protocol protocol;
 
-#if not defined(RCSwitchDisableReceiving)
+#ifndef RCSwitchDisableReceiving
     static int nReceiveTolerance;
     volatile static unsigned long nReceivedValue;
     volatile static unsigned int nReceivedBitlength;

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -123,6 +123,10 @@ class RCSwitch
     struct Protocol
     {
         uint8_t protocolId;
+
+        uint8_t changeCount; // the number of changes in the protocol (assuming all transmissions are the same lenght)
+                             // testing the protocol match is mutch faster with comparing the changeCount
+
         /** base pulse length in microseconds, e.g. 350 */
         uint16_t pulseLength;
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # rc-switch
-[![Build Status](https://travis-ci.org/perivar/rc-switch.svg?branch=master)](https://travis-ci.org/perivar/rc-switch)
+[![Build Status](https://travis-ci.org/Attila-FIN/rc-switch.svg?branch=master)](https://travis-ci.org/Attila-FIN/rc-switch)
+
 
 Use your Arduino or Raspberry Pi to operate remote radio controlled devices
 
@@ -11,6 +12,11 @@ rc-switch is also listed in the arduino library manager.
 
 Modified to support Nexa and Everflourish
 https://github.com/perivar/rc-switch
+
+Modified to support for Cixi Yidong Electronics protocol.
+Remote control switches are sold under brands AXXEL, Telco, EVOLOGY, CONECTO, mumbi, Manax etc.
+More info about the protocol:
+http://ipfone.hu/reverse-engineering-the-433mhz-cixi-yidong-electronics-protocol/
 
 ## Wiki
 https://github.com/sui77/rc-switch/wiki


### PR DESCRIPTION
Hi perivar!
I added a new protocol (Cixi Yidong) support, perhaps you can merge it. And eventually have it in the original code. 
I also introduced the protocol ID field in the protocol definition struct, which could help at interpretation and also at generation of the data: instead of checking the values of certain characteristics of the protocol, it is enough the check the id of the current protocol. You might consider using that too in the protocols you implemented.
I' not sure if RCSwitch::dec2binWzerofill is needed, I just used  Serial.println(code, BIN) to dump the code as binary string in debug messages.
I continued separation of the start/sync term from the pause/end bits term usage in comments.
I did not implement any protocol specific ON/OFF function, only receiving and sending bit stream string and long values.
I used the library in OpenMQTTGateway, and worked well (except that I needed to fix there to use a two digit (11) protocol ID.