### PR TITLE
Adjust Shi Qiong - 1+32 bit protocol handling

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -854,7 +854,7 @@ bool RECEIVE_ATTR RCSwitch::receiveProtocol(const int p, unsigned int changeCoun
   // The first place of the received timings array holds the pause length (low period). It is compared to the protocol specified low period length.
     unsigned int pauseLowDuration;
   pauseLowDuration = (pro.invertedSignal) ? (pro.pulseLength * pro.pause.high) : (pro.pulseLength * pro.pause.low);
-  const unsigned int pauseTolerance = (pauseLowDuration * RCSwitch::nReceiveTolerance / 100) * 0.7; //70% of the general tolerance is enough here
+  const unsigned int pauseTolerance = (pauseLowDuration * (RCSwitch::nReceiveTolerance / 100.0)) * 0.7; //70% of the general tolerance is enough here
 #ifdef DEBUG
     Serial.print(F("Protocol pause/end LOW duration: "));
     Serial.println(pauseLowDuration);
@@ -879,12 +879,12 @@ bool RECEIVE_ATTR RCSwitch::receiveProtocol(const int p, unsigned int changeCoun
   
 
   // Calculate the different tolerance values (RCSwitch::nReceiveTolerance % of the low or high durations)
-  const unsigned int syncLowTolerance = calculatedPulseLength * pro.sync.low * RCSwitch::nReceiveTolerance / 100;
-  const unsigned int syncHighTolerance = calculatedPulseLength * pro.sync.high * RCSwitch::nReceiveTolerance / 100;
-  const unsigned int oneLowTolerance = calculatedPulseLength * pro.one.low * RCSwitch::nReceiveTolerance / 100;
-  const unsigned int oneHighTolerance = calculatedPulseLength * pro.one.high * RCSwitch::nReceiveTolerance / 100;
-  const unsigned int zeroLowTolerance = calculatedPulseLength * pro.zero.low * RCSwitch::nReceiveTolerance / 100;
-  const unsigned int zeroHighTolerance = calculatedPulseLength * pro.zero.high * RCSwitch::nReceiveTolerance / 100;
+  const unsigned int syncLowTolerance = calculatedPulseLength * pro.sync.low * (RCSwitch::nReceiveTolerance / 100.0);
+  const unsigned int syncHighTolerance = calculatedPulseLength * pro.sync.high * (RCSwitch::nReceiveTolerance / 100.0);
+  const unsigned int oneLowTolerance = calculatedPulseLength * pro.one.low * (RCSwitch::nReceiveTolerance / 100.0);
+  const unsigned int oneHighTolerance = calculatedPulseLength * pro.one.high * (RCSwitch::nReceiveTolerance / 100.0);
+  const unsigned int zeroLowTolerance = calculatedPulseLength * pro.zero.low * (RCSwitch::nReceiveTolerance / 100.0);
+  const unsigned int zeroHighTolerance = calculatedPulseLength * pro.zero.high * (RCSwitch::nReceiveTolerance / 100.0);
   
 
   // store bits in the receivedBits char array (to support longer frames)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Remote control switches are sold under brands AXXEL, Telco, EVOLOGY, CONECTO, mu
 More info about the protocol:
 http://ipfone.hu/reverse-engineering-the-433mhz-cixi-yidong-electronics-protocol/
 
+Modified to support for Shi Qiong - 1+32 bit protocol.
+(https://www.alibaba.com/product-detail/Germany-type-Remote-Control-Socket-outdoor_60651648731.html)
+Remote control switches are sold under brands AXXEL in Finland. The switch receives 1+32 bit message. The 1st bit is a normal "1" bit as start. The following 32 bits consists of the 24 bits data + 8 bits checksum. Currently the checksum calculation formula is unknown, it is not any standard CRC, reverse engineering using tool reveng has been unsuccessful. Of course, replaying the code received from the remote will always work. Also using simple trial and error method can reveal new acceptable codes. You need to find ON message only, the OFF message is simply inverting the 2nd bit in the last two bytes (2nd and 10th in the 32 bit data, counted from the LSB). Example working turn ON messages: 656A1EAE 656A1AAA 656A16A6 656A0EB6 C96A1E46 FF6A1E72  FF6C1E74 FF6E1E76 FF701E60 FF721E62 FF021E1C  0F021E94 01021E9C  01020E8C.
+1st and 2nd bytes can get many different values (perhaps remote/group ID), but 3rd byte (A, B, C, D or ALL buttons) seems to work only with value 0x1E, 0x1A 0x16, 0x0E, 0x08, where 0x08 is the turn ON ALL switches, where they were taught with the same remote/group ID.
+
 ## Wiki
 https://github.com/sui77/rc-switch/wiki
 


### PR DESCRIPTION
Hi perivar,  I needed to adjust the Shi Qiong protocol handling a bit :).
Please note, that by introducing the changeCount in protocol definition, currently protocols 2 to 12 do NOT have the correct values. However if you have one of those remotes, you can find the proper value in debug mode on serial console:  "Change count/number of timings is: ". Just capture the right value and add to the protocol definition.

My last commits are:
- Protocol uses 1st bit "1" start bit
- README.md incudes Shi Qiong - 1+32 bit protocol description