### PR TITLE
Correct AC123 timing read from logic analizer

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -100,7 +100,7 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
     {13, 68, 100, {0, 0}, {3, 8}, {8, 3}, {3, 100}, false},       // protocol 13 (Shi Qiong) - 1+32 bit protocol. The first bit is a leading "1"  
     {14, 26, 50, {7, 8}, {8, 15}, {15, 8}, {15, 340}, false },    // protocol 14 (Mertik Maxitrol G6R-H4T1)	
     {15, 42, 20, {0, 0}, {40, 20}, {20, 40}, {340, 20}, true },   // protocol 15 (Ferport TAC4KR)
-    {16, 132, 50, {99, 13}, {5, 13}, {11, 6}, {11, 101}, false }, // protocol 16 (AC123)	
+    {16, 132, 50, {100, 12}, {5.6, 12}, {12, 5.6}, {12, 100}, false }, // protocol 16 (AC123)	
 };
 
 enum

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -85,22 +85,22 @@ static const RCSwitch::Protocol proto[] = {
 #else
 static const RCSwitch::Protocol PROGMEM proto[] = {
 #endif
-    {1, 50, 290, {0, 0}, {1, 3}, {3, 1}, {1, 31}, false},         // protocol 1 (EV1527)
-    {2, 255, 650, {0, 0}, {1, 2}, {2, 1}, {1, 10}, false},        // protocol 2
-    {3, 255, 100, {0, 0}, {4, 11}, {9, 6}, {30, 71}, false},      // protocol 3
-    {4, 255, 380, {0, 0}, {1, 3}, {3, 1}, {1, 6}, false},         // protocol 4
-    {5, 255, 500, {0, 0}, {1, 2}, {2, 1}, {6, 14}, false},        // protocol 5
-    {6, 255, 450, {0, 0}, {1, 2}, {2, 1}, {23, 1}, true},         // protocol 6 (HT6P20B)
-    {7, 255, 150, {0, 0}, {1, 6}, {6, 1}, {2, 62}, false},        // protocol 7 (HS2303-PT, i. e. used in AUKEY Remote)
-    {8, 255, 250, {1, 10}, {1, 5}, {1, 1}, {1, 40}, false},       // protocol 8 (Nexa)
-    {9, 255, 100, {0, 0}, {6, 6}, {6, 12}, {6, 169}, false},      // protocol 9 (Everflourish Single Button)
-    {10, 255, 100, {0, 0}, {6, 6}, {6, 12}, {6, 120}, false},     // protocol 10 (Everflourish All Buttons)
-    {11, 88, 100, {34, 34}, {5, 4}, {5, 13}, {2, 200}, false},    // protocol 11 (Cixi Yidong Electronics , sold as AXXEL, Telco, EVOLOGY, CONECTO, mumbi, Manax etc.)
-    {12, 26, 333, {0, 1}, {1, 2}, {2, 1}, {45, 0}, true},         // protocol 12 (CAME)  
-    {13, 68, 100, {0, 0}, {3, 8}, {8, 3}, {3, 100}, false},       // protocol 13 (Shi Qiong) - 1+32 bit protocol. The first bit is a leading "1"  
-    {14, 26, 50, {7, 8}, {8, 15}, {15, 8}, {15, 340}, false },    // protocol 14 (Mertik Maxitrol G6R-H4T1)	
-    {15, 42, 20, {0, 0}, {40, 20}, {20, 40}, {340, 20}, true },   // protocol 15 (Ferport TAC4KR)
-    {16, 132, 50, {100, 12}, {5.6, 12}, {12, 5.6}, {12, 100}, false }, // protocol 16 (AC123)	
+    {1, 50, 290, 0, {0, 0}, {1, 3}, {3, 1}, {1, 31}, false},         // protocol 1 (EV1527)
+    {2, 255, 650, 0, {0, 0}, {1, 2}, {2, 1}, {1, 10}, false},        // protocol 2
+    {3, 255, 100, 0, {0, 0}, {4, 11}, {9, 6}, {30, 71}, false},      // protocol 3
+    {4, 255, 380, 0, {0, 0}, {1, 3}, {3, 1}, {1, 6}, false},         // protocol 4
+    {5, 255, 500, 0, {0, 0}, {1, 2}, {2, 1}, {6, 14}, false},        // protocol 5
+    {6, 255, 450, 0, {0, 0}, {1, 2}, {2, 1}, {23, 1}, true},         // protocol 6 (HT6P20B)
+    {7, 255, 150, 0, {0, 0}, {1, 6}, {6, 1}, {2, 62}, false},        // protocol 7 (HS2303-PT, i. e. used in AUKEY Remote)
+    {8, 255, 250, 0, {1, 10}, {1, 5}, {1, 1}, {1, 40}, false},       // protocol 8 (Nexa)
+    {9, 255, 100, 0, {0, 0}, {6, 6}, {6, 12}, {6, 169}, false},      // protocol 9 (Everflourish Single Button)
+    {10, 255, 100, 0, {0, 0}, {6, 6}, {6, 12}, {6, 120}, false},     // protocol 10 (Everflourish All Buttons)
+    {11, 88, 100, 0, {34, 34}, {5, 4}, {5, 13}, {2, 200}, false},    // protocol 11 (Cixi Yidong Electronics , sold as AXXEL, Telco, EVOLOGY, CONECTO, mumbi, Manax etc.)
+    {12, 26, 333, 0, {0, 1}, {1, 2}, {2, 1}, {45, 0}, true},         // protocol 12 (CAME)  
+    {13, 68, 100, 0, {0, 0}, {3, 8}, {8, 3}, {3, 100}, false},       // protocol 13 (Shi Qiong) - 1+32 bit protocol. The first bit is a leading "1"  
+    {14, 26, 50, 0, {7, 8}, {8, 15}, {15, 8}, {15, 340}, false },    // protocol 14 (Mertik Maxitrol G6R-H4T1)	
+    {15, 42, 20, 0, {0, 0}, {40, 20}, {20, 40}, {340, 20}, true },   // protocol 15 (Ferport TAC4KR)
+    {16, 132, 50, 8, {100, 12}, {5.6f, 12}, {12, 5.6f}, {12, 100}, false }, // protocol 16 (AC123)
 };
 
 enum
@@ -546,6 +546,11 @@ void RCSwitch::send(const char *sBitString)
     this->disableReceive();
   }
 #endif
+
+  for (int nRepeat = 0; nRepeat < protocol.initSyncLength; nRepeat++)
+  {
+    this->transmit(protocol.zero);
+  }
 
   for (int nRepeat = 0; nRepeat < nRepeatTransmit; nRepeat++)
   {

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -85,22 +85,22 @@ static const RCSwitch::Protocol proto[] = {
 #else
 static const RCSwitch::Protocol PROGMEM proto[] = {
 #endif
-    {1, 50, 290, 0, {0, 0}, {1, 3}, {3, 1}, {1, 31}, false},         // protocol 1 (EV1527)
-    {2, 255, 650, 0, {0, 0}, {1, 2}, {2, 1}, {1, 10}, false},        // protocol 2
-    {3, 255, 100, 0, {0, 0}, {4, 11}, {9, 6}, {30, 71}, false},      // protocol 3
-    {4, 255, 380, 0, {0, 0}, {1, 3}, {3, 1}, {1, 6}, false},         // protocol 4
-    {5, 255, 500, 0, {0, 0}, {1, 2}, {2, 1}, {6, 14}, false},        // protocol 5
-    {6, 255, 450, 0, {0, 0}, {1, 2}, {2, 1}, {23, 1}, true},         // protocol 6 (HT6P20B)
-    {7, 255, 150, 0, {0, 0}, {1, 6}, {6, 1}, {2, 62}, false},        // protocol 7 (HS2303-PT, i. e. used in AUKEY Remote)
-    {8, 255, 250, 0, {1, 10}, {1, 5}, {1, 1}, {1, 40}, false},       // protocol 8 (Nexa)
-    {9, 255, 100, 0, {0, 0}, {6, 6}, {6, 12}, {6, 169}, false},      // protocol 9 (Everflourish Single Button)
-    {10, 255, 100, 0, {0, 0}, {6, 6}, {6, 12}, {6, 120}, false},     // protocol 10 (Everflourish All Buttons)
-    {11, 88, 100, 0, {34, 34}, {5, 4}, {5, 13}, {2, 200}, false},    // protocol 11 (Cixi Yidong Electronics , sold as AXXEL, Telco, EVOLOGY, CONECTO, mumbi, Manax etc.)
-    {12, 26, 333, 0, {0, 1}, {1, 2}, {2, 1}, {45, 0}, true},         // protocol 12 (CAME)  
-    {13, 68, 100, 0, {0, 0}, {3, 8}, {8, 3}, {3, 100}, false},       // protocol 13 (Shi Qiong) - 1+32 bit protocol. The first bit is a leading "1"  
-    {14, 26, 50, 0, {7, 8}, {8, 15}, {15, 8}, {15, 340}, false },    // protocol 14 (Mertik Maxitrol G6R-H4T1)	
-    {15, 42, 20, 0, {0, 0}, {40, 20}, {20, 40}, {340, 20}, true },   // protocol 15 (Ferport TAC4KR)
-    {16, 132, 50, 8, {100, 12}, {5.6f, 12}, {12, 5.6f}, {12, 100}, false }, // protocol 16 (AC123)
+    {1, 50, 290, {0, 0}, {1, 3}, {3, 1}, {1, 31}, false},         // protocol 1 (EV1527)
+    {2, 255, 650, {0, 0}, {1, 2}, {2, 1}, {1, 10}, false},        // protocol 2
+    {3, 255, 100, {0, 0}, {4, 11}, {9, 6}, {30, 71}, false},      // protocol 3
+    {4, 255, 380, {0, 0}, {1, 3}, {3, 1}, {1, 6}, false},         // protocol 4
+    {5, 255, 500, {0, 0}, {1, 2}, {2, 1}, {6, 14}, false},        // protocol 5
+    {6, 255, 450, {0, 0}, {1, 2}, {2, 1}, {23, 1}, true},         // protocol 6 (HT6P20B)
+    {7, 255, 150, {0, 0}, {1, 6}, {6, 1}, {2, 62}, false},        // protocol 7 (HS2303-PT, i. e. used in AUKEY Remote)
+    {8, 255, 250, {1, 10}, {1, 5}, {1, 1}, {1, 40}, false},       // protocol 8 (Nexa)
+    {9, 255, 100, {0, 0}, {6, 6}, {6, 12}, {6, 169}, false},      // protocol 9 (Everflourish Single Button)
+    {10, 255, 100, {0, 0}, {6, 6}, {6, 12}, {6, 120}, false},     // protocol 10 (Everflourish All Buttons)
+    {11, 88, 100, {34, 34}, {5, 4}, {5, 13}, {2, 200}, false},    // protocol 11 (Cixi Yidong Electronics , sold as AXXEL, Telco, EVOLOGY, CONECTO, mumbi, Manax etc.)
+    {12, 26, 333, {0, 1}, {1, 2}, {2, 1}, {45, 0}, true},         // protocol 12 (CAME)  
+    {13, 68, 100, {0, 0}, {3, 8}, {8, 3}, {3, 100}, false},       // protocol 13 (Shi Qiong) - 1+32 bit protocol. The first bit is a leading "1"  
+    {14, 26, 50, {7, 8}, {8, 15}, {15, 8}, {15, 340}, false },    // protocol 14 (Mertik Maxitrol G6R-H4T1)	
+    {15, 42, 20, {0, 0}, {40, 20}, {20, 40}, {340, 20}, true },   // protocol 15 (Ferport TAC4KR)
+    {16, 132, 50, {100, 12}, {5.6f, 12}, {12, 5.6f}, {12, 100}, false }, // protocol 16 (AC123)
 };
 
 enum
@@ -546,11 +546,6 @@ void RCSwitch::send(const char *sBitString)
     this->disableReceive();
   }
 #endif
-
-  for (int nRepeat = 0; nRepeat < protocol.initSyncLength; nRepeat++)
-  {
-    this->transmit(protocol.zero);
-  }
 
   for (int nRepeat = 0; nRepeat < nRepeatTransmit; nRepeat++)
   {

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -130,6 +130,8 @@ class RCSwitch
         /** base pulse length in microseconds, e.g. 350 */
         uint16_t pulseLength;
 
+        uint8_t initSyncLength;  // number of zero sync bits before the transmission
+
         HighLow sync;  // sync bit before the data bits (normally zero, i.e. 0, 0)
         HighLow zero;  // zero bit
         HighLow one;   // one bit

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -130,8 +130,6 @@ class RCSwitch
         /** base pulse length in microseconds, e.g. 350 */
         uint16_t pulseLength;
 
-        uint8_t initSyncLength;  // number of zero sync bits before the transmission
-
         HighLow sync;  // sync bit before the data bits (normally zero, i.e. 0, 0)
         HighLow zero;  // zero bit
         HighLow one;   // one bit

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -112,8 +112,8 @@ class RCSwitch
      */
     struct HighLow
     {
-        uint16_t high;
-        uint16_t low;
+        float high;
+        float low;
     };
 
     /**


### PR DESCRIPTION
Hi, I have read correct values with logic analyzer of AC123, the issue is that it contains 280us (micro seconds) which is 5.6% of 50ms, but HighLow has unsigned int values and does not accept real values, what should I do?

`{16, 132, 50, {100, 12}, {5.6, 12}, {12, 5.6}, {12, 100}, false }, // protocol 16 (AC123)`

Also it has 8 zeroes in front of the 12 repeated transmissions (not sure are they important?) I guess I can send them outside of the lib code with transmist

![image](https://github.com/user-attachments/assets/c4f5a65b-4109-4a34-80e2-f3608bd7f1b3)
